### PR TITLE
network call to null url when call destroy()

### DIFF
--- a/src/js/cropper.js
+++ b/src/js/cropper.js
@@ -66,7 +66,7 @@ class Cropper {
       self.isImg = true;
 
       // e.g.: "img/picture.jpg"
-      url = element.getAttribute('src');
+      url = element.getAttribute('src') || '';
       self.originalUrl = url;
 
       // Stop when it's a blank image


### PR DESCRIPTION
If image do not have src at the beginning, the originalUrl is null.
On destroy, we replace the image by the original one. Due to this null value, we have a network call to an url who do not exist.
with empty originalUrl, we do not have this issue.